### PR TITLE
chore: Add dependabot config so it is on by default

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,15 @@
+version: 1
+update_configs:
+  # Keep package.json (& lockfiles) up to date as soon as
+  # new versions are published to the npm registry
+  - package_manager: "javascript"
+    directory: "/assets"
+    update_schedule: "live"
+  # Keep Dockerfile up to date, pulling new versions ASAP
+  - package_manager: "docker"
+    directory: "/"
+    update_schedule: "live"
+  # Keep Mix up to date, pulling new versions ASAP
+  - package_manager: "elixir:hex"
+    directory: "/"
+    update_schedule: "live"


### PR DESCRIPTION
connects to revelrylabs/engineering-meeting#115

#### Description: <!-- What changed? Why? -->

We want to use dependabot by default on projects going forward. It turns out that we can automate this setup and encourage consistent config by adding a dependabot config to our repos. This adds it to the template so that all generated projects benefit.

#### Reviewer don't-forgets:

- [ ] Test coverage feels appropriate, given potential risk
- [ ] We're not doubling down on already-bad code
- [ ] If there are web UI changes, they don't add anything that could be considered client-side page navigation (unless pre-approved as being necessary by another engineer)
- [ ] If there are web UI changes, they don't add any AJAX form submits (unless pre-approved as being necessary by another engineer)
- [ ] If there are any lint rules disabled, they are disabled per-line, and were (in the reviewer's judgment) appropriate to disable
- [ ] Any new environment variables used in the app are both documented and have been added to both staging and production environments already
- [ ] Potential race conditions are either inconsequential, or the code prevents them from occurring.
- [ ] If this is a UI change that called for screenshots/GIFs, in the reviewer's judgement, they were included
