### PR TITLE
dependabot doesn't support live updates for docker

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -8,7 +8,7 @@ update_configs:
   # Keep Dockerfile up to date, pulling new versions ASAP
   - package_manager: "docker"
     directory: "/"
-    update_schedule: "live"
+    update_schedule: "daily"
   # Keep Mix up to date, pulling new versions ASAP
   - package_manager: "elixir:hex"
     directory: "/"


### PR DESCRIPTION
It looks like dependabot doesn't support the live update_schedule for docker. I'm not sure if setting it to live is a the way to is future proof it so that it will be live if they ever support it. But I it thought it was more likely to break it. Not sure but throught i'd put it up here.

https://dependabot.com/docs/config-file/#update_schedule-required