### PR TITLE
update stalebot label

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,7 +7,7 @@ exemptLabels:
   - pinned
   - security
 # Label to use when marking an issue as stale
-staleLabel: wontfix
+staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had


### PR DESCRIPTION
This updates the stalebot config to match the ones we use in the other repos. We are only changing the label to `stale` instead of `wontfix`. The reason is because this is more descriptive in what actually happened to the issue and won't cause confusion for product owners/etc when it gets labeled.