### PR TITLE
add git depth: false to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 sudo: false
+git:
+  depth: false
 jobs:
   include:
     - stage: 'Tests' # naming the Tests stage


### PR DESCRIPTION
should fix these "shallow update not allowed" errors during deploys (iirc) https://travis-ci.com/revelrylabs/revelry_phoenix_app_template/jobs/189662289#L1060
