### PR TITLE
fix docker login for travis deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ jobs:
       if: branch = master
       script: skip
       before_deploy:
-        - echo $DOCKER_PASSWORD | docker login harbor.revelry-prod.revelry.net
+        - echo $DOCKER_PASSWORD | docker login harbor.revelry-prod.revelry.net -u $DOCKER_USER --password-stdin
       deploy:
         provider: script
         script: bin/docker_pub library/app-template harbor.revelry-prod.revelry.net


### PR DESCRIPTION
connects to #[issue number]

#### Description: <!-- What changed? Why? -->
I made a small mistake when I moved the docker login out of my script and into the before_deploy hook. This should fix it.