### PR TITLE
docker exposes the branch name as an env variable

### DIFF
--- a/bin/docker_pub
+++ b/bin/docker_pub
@@ -13,7 +13,7 @@ docker pull $LATEST_TAG || true
 docker build --cache-from $LATEST_TAG -t $VERSIONED_TAG . || exit 1
 docker push $VERSIONED_TAG || exit 1
 
-if [ "$BRANCH" = "master" ]; then
+if [ "$TRAVIS_BRANCH" = "master" ]; then
   docker tag $VERSIONED_TAG $LATEST_TAG
   docker push $LATEST_TAG
 fi


### PR DESCRIPTION

#### Description: <!-- What changed? Why? -->
For some reason git reports that `HEAD` is checked out instead of the branch name when deploying, but it's exposed via the build environment.