### PR TITLE
Have harmonium translate error messages by default

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -52,6 +52,8 @@ config :ex_aws,
 
 config :app_template, jwt_secret: "secret"
 
+config :harmonium, :error_helper, &AppTemplateWeb.ErrorHelpers.translate_error/1
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"


### PR DESCRIPTION
#### Description: 
Supply the necessary config to have harmonium form helpers translate error messages using the app's `gettext` dictionaries


#### Reviewer don't-forgets:

- [ ] Test coverage feels appropriate, given potential risk
- [ ] We're not doubling down on already-bad code
- [ ] If there are web UI changes, they don't add anything that could be considered client-side page navigation (unless pre-approved as being necessary by another engineer)
- [ ] If there are web UI changes, they don't add any AJAX form submits (unless pre-approved as being necessary by another engineer)
- [ ] If there are any lint rules disabled, they are disabled per-line, and were (in the reviewer's judgment) appropriate to disable
- [ ] Any new environment variables used in the app are both documented and have been added to both staging and production environments already
- [ ] Potential race conditions are either inconsequential, or the code prevents them from occurring.
- [ ] If this is a UI change that called for screenshots/GIFs, in the reviewer's judgement, they were included
