### PR TITLE
Add rollbar deploy pings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,9 @@ jobs:
       script: skip
       before_deploy:
         - echo $DOCKER_PASSWORD | docker login harbor.revelry-prod.revelry.net -u $DOCKER_USERNAME --password-stdin
+        - export ROLLBAR_DEPLOY_ID=$(./bin/rollbar_release started)
+      after_deploy:
+        - ./bin/rollbar_release succeeded
       deploy:
         provider: script
         script: bin/docker_pub library/app-template harbor.revelry-prod.revelry.net

--- a/bin/rollbar_release
+++ b/bin/rollbar_release
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+STAGE=$1
+
+if [ "$STAGE" = "" ]; then
+  echo "Please provide a stage argument: 'started', 'succeeded', 'failed', or 'timed_out'"
+  echo "e.g. 'rollbar_release started'"
+  exit 1
+fi
+
+if [ "$ROLLBAR_ACCESS_TOKEN" = "" ]; then
+  echo "No ROLLBAR_ACCESS_TOKEN found in the environment. Skipping release ping"
+  exit 1
+fi
+
+if [ "$TRAVIS_BRANCH" != "master" ]; then
+  # if you want to track non-prod deploys, add some logic
+  # to set the environment (in OUTPUT below) based on $TRAVIS_BRANCH
+  echo "Skipping release ping for branch $TRAVIS_BRANCH"
+  exit 0
+fi
+
+if [ "$STAGE" = "started" ]; then
+  OUTPUT=$(
+    curl --request POST \
+      --url https://api.rollbar.com/api/1/deploy/ \
+      --silent \
+      --data "access_token=$ROLLBAR_ACCESS_TOKEN" \
+      --data "environment=production" \
+      --data "revision=$TRAVIS_COMMIT" \
+      --data "comment=$TRAVIS_TAG" \
+      --data "status=$STAGE"
+  )
+  DEPLOY_ID_REGEX='"deploy_id": ([0-9]+)'
+  [[ $OUTPUT =~ $DEPLOY_ID_REGEX ]]
+  ROLLBAR_DEPLOY_ID=${BASH_REMATCH[1]}
+  echo $ROLLBAR_DEPLOY_ID
+else
+  curl --request PATCH \
+    --url "https://api.rollbar.com/api/1/deploy/$ROLLBAR_DEPLOY_ID" \
+    --data "access_token=$ROLLBAR_ACCESS_TOKEN" \
+    --data "status=$STAGE"
+  echo "updated rollbar deployment $ROLLBAR_DEPLOY_ID"
+fi


### PR DESCRIPTION
#### Description: Add a script to hit the Rollbar API to
- record a Deployment in Rollbar when the deployment starts
- update that deployment's state to Succeeded once the deploy finishes


#### Reviewer don't-forgets:

- [ ] Test coverage feels appropriate, given potential risk
- [ ] We're not doubling down on already-bad code
- [ ] If there are web UI changes, they don't add anything that could be considered client-side page navigation (unless pre-approved as being necessary by another engineer)
- [ ] If there are web UI changes, they don't add any AJAX form submits (unless pre-approved as being necessary by another engineer)
- [ ] If there are any lint rules disabled, they are disabled per-line, and were (in the reviewer's judgment) appropriate to disable
- [ ] Any new environment variables used in the app are both documented and have been added to both staging and production environments already
- [ ] Potential race conditions are either inconsequential, or the code prevents them from occurring.
- [ ] If this is a UI change that called for screenshots/GIFs, in the reviewer's judgement, they were included
