### PR TITLE
Allow clustering to work for non-prod apps in the cluster

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -39,7 +39,7 @@ config :ex_aws,
 
 config :app_template, jwt_secret: "secret"
 
-# see prod.exs for production config
+# see releases.exs for production config
 config :app_template, cluster_topologies: []
 
 # Import environment specific config. This must remain at the bottom

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -24,13 +24,3 @@ config :rollbax, enable_crash_reports: true
 config :app_template, AppTemplate.Mailer,
   adapter: Bamboo.SendGridAdapter,
   api_key: System.get_env("SENDGRID_API_KEY")
-
-config :app_template, cluster_topologies: [
-  k8s: [
-    strategy: Elixir.Cluster.Strategy.Kubernetes.DNS,
-    config: [
-      service: "app-template-nodes",
-      application_name: "app-template",
-    ]
-  ]
-]

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -28,3 +28,16 @@ config :app_template, AppTemplate.Mailer,
 
 config :app_template,
   jwt_secret: System.get_env("JWT_SECRET") || System.get_env("SECRET_KEY_BASE")
+
+app_name = System.get_env("APP_NAME") || "app-template"
+config :app_template, cluster_topologies: [
+  k8s: [
+    strategy: Elixir.Cluster.Strategy.Kubernetes.DNS,
+    config: [
+      # the name of the "headless" service in the app's k8s configuration
+      service: "#{app_name}-nodes",
+      # the `app` tag applied to k8s resources for this app
+      application_name: app_name,
+    ]
+  ]
+]

--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -12,6 +12,9 @@
 # RELEASE_DISTRIBUTION variable below.
 # - The NODE_IP environment variable should be set in the k8s deployment definition
 # - The COOKIE environment variable should be set in the app's config secret
+# - The APP_NAME environment variable should match the `app` tag applied to
+#   this app's k8s resources, which is probably `app-template` in prod but would be
+#   different in staging or review apps
 export RELEASE_DISTRIBUTION=name
-export RELEASE_NODE=app-template@$NODE_IP
+export RELEASE_NODE=${APP_NAME:-app-template}@$NODE_IP
 export RELEASE_COOKIE=$COOKIE


### PR DESCRIPTION
#### Description:
Allow Elixir clustering to work for non-production deployments of the same app. E.g. staging nodes would talk to one another but not to prod nodes.

Please check me: If `APP_NAME` isn't set, or if it's set to `"app-template"`, this PR shouldn't affect anything.

#### Reviewer don't-forgets:

- [ ] Test coverage feels appropriate, given potential risk
- [ ] We're not doubling down on already-bad code
- [ ] If there are web UI changes, they don't add anything that could be considered client-side page navigation (unless pre-approved as being necessary by another engineer)
- [ ] If there are web UI changes, they don't add any AJAX form submits (unless pre-approved as being necessary by another engineer)
- [ ] If there are any lint rules disabled, they are disabled per-line, and were (in the reviewer's judgment) appropriate to disable
- [ ] Any new environment variables used in the app are both documented and have been added to both staging and production environments already
- [ ] Potential race conditions are either inconsequential, or the code prevents them from occurring.
- [ ] If this is a UI change that called for screenshots/GIFs, in the reviewer's judgement, they were included
