### PR TITLE
Fix .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,13 @@ jobs:
       services:
         - postgresql
       before_script:
-        - nvm install 12.4.0 && nvm use 12.4.0
         - psql -c 'create database app_template_test;' -U postgres
       install:
         - gem install coveralls-multi
         - mix local.hex --force
         - mix local.rebar --force
         - mix deps.get
+        - nvm install 12.4.0 && nvm use 12.4.0
         - npm install --prefix assets
       script:
         - MIX_ENV=test mix coveralls.json


### PR DESCRIPTION
#### Description: <!-- What changed? Why? -->

This fixes the issue where `npm packages` aren't installed completely in certain cases. The change explicitly states which `Node.js` version we should be running with it's bundling `npm`. It'll skip any problems where we might be running tests against an outdated version of `Node.js` or `npm` that we aren't developing against.

#### Reviewer don't-forgets:

- [ ] Test coverage feels appropriate, given potential risk
- [ ] We're not doubling down on already-bad code
- [ ] If there are web UI changes, they don't add anything that could be considered client-side page navigation (unless pre-approved as being necessary by another engineer)
- [ ] If there are web UI changes, they don't add any AJAX form submits (unless pre-approved as being necessary by another engineer)
- [ ] If there are any lint rules disabled, they are disabled per-line, and were (in the reviewer's judgment) appropriate to disable
- [ ] Any new environment variables used in the app are both documented and have been added to both staging and production environments already
- [ ] Potential race conditions are either inconsequential, or the code prevents them from occurring.
- [ ] If this is a UI change that called for screenshots/GIFs, in the reviewer's judgement, they were included
