### PR TITLE
Fix error reporter sanitization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
       before_script:
         - psql -c 'create database app_template_test;' -U postgres
       before_install:
-        - wget https://chromedriver.storage.googleapis.com/76.0.3809.68/chromedriver_linux64.zip
+        - wget https://chromedriver.storage.googleapis.com/78.0.3904.70/chromedriver_linux64.zip
         - unzip chromedriver_linux64.zip
         - sudo apt-get install libnss3
         - sudo cp chromedriver /usr/local/bin/.

--- a/test/app_template_web/error_reporter_test.exs
+++ b/test/app_template_web/error_reporter_test.exs
@@ -29,4 +29,15 @@ defmodule AppTemplateWeb.ErrorReporter.Test do
              stack: []
            }) == :ok
   end
+
+  test "sanitize sensitive data" do
+    params = %{"password" => "password", "user" => %{"new_password" => "new_password"}}
+
+    assert ErrorReporter.sanitize(params) == %{
+      "password" => "[FILTERED]",
+      "user" => %{
+        "new_password" => "[FILTERED]"
+      }
+    }
+  end
 end


### PR DESCRIPTION
#### Description: <!-- What changed? Why? -->

This updates the ErrorReporter to:
- sanitize additional params that are in the default app template (account and session controller)
- handle situations where the fields are nested when used with changesets

#### Reviewer don't-forgets:

- [ ] Test coverage feels appropriate, given potential risk
- [ ] We're not doubling down on already-bad code
- [ ] If there are web UI changes, they don't add anything that could be considered client-side page navigation (unless pre-approved as being necessary by another engineer)
- [ ] If there are web UI changes, they don't add any AJAX form submits (unless pre-approved as being necessary by another engineer)
- [ ] If there are any lint rules disabled, they are disabled per-line, and were (in the reviewer's judgment) appropriate to disable
- [ ] Any new environment variables used in the app are both documented and have been added to both staging and production environments already
- [ ] Potential race conditions are either inconsequential, or the code prevents them from occurring.
- [ ] If this is a UI change that called for screenshots/GIFs, in the reviewer's judgement, they were included
