### PR TITLE
Log instead of hitting Rollbar on 404 errors

### DIFF
--- a/lib/app_template_web/error_reporter.ex
+++ b/lib/app_template_web/error_reporter.ex
@@ -3,6 +3,7 @@ defmodule AppTemplateWeb.ErrorReporter do
   Takes care of reporting router errors.
   """
   alias Plug.Conn
+  require Logger
 
   @filtered_params [
     "current_password",
@@ -20,6 +21,12 @@ defmodule AppTemplateWeb.ErrorReporter do
   def handle_errors(%{request_path: request_path}, _)
       when request_path in @ignore_error_routes do
     nil
+  end
+
+  # Write to logs instead of triggering Rollbar on 404s
+  # the message looks like `404: no route found for GET /bad-url (AppTemplateWeb.Router)`
+  def handle_errors(_conn, %{reason: %Phoenix.Router.NoRouteError{} = reason}) do
+    Logger.info("404: #{reason.message}")
   end
 
   def handle_errors(conn, %{kind: kind, reason: reason, stack: stacktrace}) do


### PR DESCRIPTION
#### Description:
Log instead of hitting Rollbar on 404 errors

I don't think it's helpful having these in Rollbar because they're not generally application errors.


#### Reviewer don't-forgets:

- [ ] Test coverage feels appropriate, given potential risk
- [ ] We're not doubling down on already-bad code
- [ ] If there are web UI changes, they don't add anything that could be considered client-side page navigation (unless pre-approved as being necessary by another engineer)
- [ ] If there are web UI changes, they don't add any AJAX form submits (unless pre-approved as being necessary by another engineer)
- [ ] If there are any lint rules disabled, they are disabled per-line, and were (in the reviewer's judgment) appropriate to disable
- [ ] Any new environment variables used in the app are both documented and have been added to both staging and production environments already
- [ ] Potential race conditions are either inconsequential, or the code prevents them from occurring.
- [ ] If this is a UI change that called for screenshots/GIFs, in the reviewer's judgement, they were included
