### PR TITLE
In prod, make sure GET requests come in on the host matching APP_DOMAIN

### DIFF
--- a/lib/app_template_web/plugs/app_domain_redirect.ex
+++ b/lib/app_template_web/plugs/app_domain_redirect.ex
@@ -1,0 +1,38 @@
+defmodule AppTemplateWeb.AppDomainRedirect do
+  @moduledoc """
+  If the hostname of the current request doesn't match the one configured
+  on the endpoint, redirect... on GET requests only
+  """
+  import Plug.Conn
+  alias AppTemplateWeb.Endpoint
+  alias Phoenix.Controller
+
+  @default_opts %{active: Mix.env() == :prod}
+
+  def init(opts) do
+    Map.merge(@default_opts, Enum.into(opts, %{}))
+  end
+
+  def call(%{method: "GET"} = conn, %{active: true}) do
+    req_host = conn.host
+    %{host: endpoint_host} = Endpoint.struct_url()
+
+    if req_host == endpoint_host do
+      conn
+    else
+      redirect_url = Endpoint.url() <> path(conn)
+
+      conn
+      |> Controller.redirect(external: redirect_url)
+      |> halt()
+    end
+  end
+
+  def call(conn, _), do: conn
+
+  defp path(%{request_path: path, query_string: ""}), do: path
+
+  defp path(%{request_path: path, query_string: query}) do
+    "#{path}?#{query}"
+  end
+end

--- a/lib/app_template_web/router.ex
+++ b/lib/app_template_web/router.ex
@@ -6,7 +6,13 @@ defmodule AppTemplateWeb.Router do
     extensions: [PowResetPassword, PowEmailConfirmation]
 
   use Plug.ErrorHandler
-  alias AppTemplateWeb.{RequireAdmin, BrowserAuthentication, APIAuthentication}
+
+  alias AppTemplateWeb.{
+    APIAuthentication,
+    AppDomainRedirect,
+    BrowserAuthentication,
+    RequireAdmin
+  }
 
   defp handle_errors(conn, error_data) do
     AppTemplateWeb.ErrorReporter.handle_errors(conn, error_data)
@@ -22,6 +28,7 @@ defmodule AppTemplateWeb.Router do
     plug :fetch_flash
     plug :protect_from_forgery
     plug :put_secure_browser_headers
+    plug AppDomainRedirect
     plug BrowserAuthentication, otp_app: :app_template
   end
 

--- a/test/app_template_web/plugs/app_domain_redirect_test.exs
+++ b/test/app_template_web/plugs/app_domain_redirect_test.exs
@@ -1,0 +1,41 @@
+defmodule AppTemplateWeb.AppDomainRedirectTest do
+  @moduledoc """
+  Tests for AppTemplateWeb.AppDomainRedirect
+  """
+  use AppTemplateWeb.ConnCase, async: true
+  alias AppTemplateWeb.AppDomainRedirect
+
+  test "init with active override" do
+    assert AppDomainRedirect.init(active: true) == %{active: true}
+  end
+
+  test "init in test env defaults to false" do
+    assert AppDomainRedirect.init([]) == %{active: false}
+  end
+
+  test "doesn't do anything when not active" do
+    conn = %{build_conn() | host: "localhurst"}
+    assert AppDomainRedirect.call(conn, %{active: false}) == conn
+  end
+
+  test "redirects from bad hostname when active" do
+    port = get_in(Application.get_env(:app_template, AppTemplateWeb.Endpoint), [:http, :port])
+    conn = %{build_conn() | host: "localhurst", request_path: "/page"}
+    redir = AppDomainRedirect.call(conn, %{active: true})
+    assert redirected_to(redir) == "http://localhost:#{port}/page"
+  end
+
+  test "preserves the query string and path" do
+    port = get_in(Application.get_env(:app_template, AppTemplateWeb.Endpoint), [:http, :port])
+
+    conn = %{
+      build_conn()
+      | host: "nondomain",
+        request_path: "/page",
+        query_string: "name=val&other=123"
+    }
+
+    redir = AppDomainRedirect.call(conn, %{active: true})
+    assert redirected_to(redir) == "http://localhost:#{port}/page?name=val&other=123"
+  end
+end


### PR DESCRIPTION
#### Description:
I've seen several apps now that are accessed on various hosts (cluster URL and custom domain) and sockets only work on one based on the `APP_DOMAIN` setting. And nobody knows it. I think it's a nice default for the app to redirect a regular browser request to the configured domain if it comes from somewhere else.

It should also help avoid spreading your search scores around on the different domains and catch sites where the `APP_DOMAIN` isn't set properly.

Previously a similar implementation caused issues for a team member's local environment, so this has been set up to only be enabled in production by default. 

#### Reviewer don't-forgets:

- [ ] Test coverage feels appropriate, given potential risk
- [ ] We're not doubling down on already-bad code
- [ ] If there are web UI changes, they don't add anything that could be considered client-side page navigation (unless pre-approved as being necessary by another engineer)
- [ ] If there are web UI changes, they don't add any AJAX form submits (unless pre-approved as being necessary by another engineer)
- [ ] If there are any lint rules disabled, they are disabled per-line, and were (in the reviewer's judgment) appropriate to disable
- [ ] Any new environment variables used in the app are both documented and have been added to both staging and production environments already
- [ ] Potential race conditions are either inconsequential, or the code prevents them from occurring.
- [ ] If this is a UI change that called for screenshots/GIFs, in the reviewer's judgement, they were included
