### PR TITLE
Update bin/bootstrap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,9 +42,9 @@ jobs:
       name: 'Integration Tests'
       language: elixir
       elixir:
-        - 1.8
+        - 1.9
       otp_release:
-        - 21.0
+        - 22.0
       cache:
         directories:
           - _build
@@ -60,7 +60,9 @@ jobs:
       before_script:
         - psql -c 'create database app_template_test;' -U postgres
       before_install:
-        - wget https://chromedriver.storage.googleapis.com/78.0.3904.70/chromedriver_linux64.zip
+        - CHROME_VERSION=`google-chrome --version | grep -oP " ([0-9]{1,3})" | cut -d" " -f2`
+        - DRIVER_VERSION=`wget -qO- https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_VERSION}`
+        - wget https://chromedriver.storage.googleapis.com/${DRIVER_VERSION}/chromedriver_linux64.zip
         - unzip chromedriver_linux64.zip
         - sudo apt-get install libnss3
         - sudo cp chromedriver /usr/local/bin/.

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,9 +42,9 @@ jobs:
       name: 'Integration Tests'
       language: elixir
       elixir:
-        - 1.9
+        - 1.8
       otp_release:
-        - 22.0
+        - 21.0
       cache:
         directories:
           - _build

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -8,6 +8,7 @@ if which asdf >/dev/null; then
     asdf plugin-add erlang https://github.com/asdf-vm/asdf-erlang.git
     asdf plugin-add nodejs https://github.com/asdf-vm/asdf-nodejs.git
     asdf plugin-add elixir https://github.com/asdf-vm/asdf-elixir.git
+    asdf plugin update --all
     asdf install
 else
     echo "asdf not found. Please make sure it is installed by following directions below and try again"


### PR DESCRIPTION
This updates the `bin/bootstrap` to have `asdf` go out and update all of the existing plugins. This might help mitigate some of the pain points when something is fixed in the plugin which may affect one of the languages installed by `asdf`.


For some additional context, `asdf-erlang` had bumped up the version for `kerl`, which is used to compile/build erlang on various environments, to fix an issue on OSX where OpenSSL  couldn't be found due to some things Apple did on their end. You would need to remember to fetch the new version of the `asdf-erlang` to make sure that erlang builds correctly. However, if that wasn't done, you'd end up with a broken install that needs to be removed and re-installed once the plugin is updated.

Note: It also doesn't hurt to grab the latest plugin versions anyway.