### PR TITLE
Make Clustering Optional

### DIFF
--- a/config/releases.exs
+++ b/config/releases.exs
@@ -20,11 +20,6 @@ config :rollbax,
   # TODO: turn on when your app is deployed
   enabled: false
 
-config :app_template, :statix,
-  prefix: "app_template",
-  host: System.get_env("DATADOG_HOST") || "100.66.67.91",
-  port: String.to_integer(System.get_env("DATADOG_PORT") || "8125")
-
 config :app_template, AppTemplate.Mailer,
   adapter: Bamboo.SendGridAdapter,
   api_key: System.get_env("SENDGRID_API_KEY")

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -32,7 +32,10 @@ config :app_template, AppTemplate.Mailer,
 config :app_template,
   jwt_secret: System.get_env("JWT_SECRET") || System.get_env("SECRET_KEY_BASE")
 
+# Configure Cluster Nodes
 app_name = System.get_env("APP_NAME") || "app-template"
+
+config :app_template, cluster_disabled: System.get_env("CLUSTER_DISABLED") == "1"
 
 config :app_template,
   cluster_topologies: [

--- a/lib/app_template/application.ex
+++ b/lib/app_template/application.ex
@@ -8,8 +8,6 @@ defmodule AppTemplate.Application do
 
     setup()
 
-    topologies = Application.get_env(:app_template, :cluster_topologies)
-
     # Define workers and child supervisors to be supervised
     children = [
       # Start the Ecto repository
@@ -18,7 +16,7 @@ defmodule AppTemplate.Application do
       supervisor(AppTemplateWeb.Endpoint, []),
       # Start your own worker by calling: AppTemplate.Worker.start_link(arg1, arg2, arg3)
       # worker(AppTemplate.Worker, [arg1, arg2, arg3]),
-      {Cluster.Supervisor, [topologies, [name: AppTemplate.ClusterSupervisor]]},
+      {Cluster.Supervisor, [cluster_topologies(), [name: AppTemplate.ClusterSupervisor]]},
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html
@@ -32,6 +30,13 @@ defmodule AppTemplate.Application do
   def config_change(changed, _new, removed) do
     AppTemplateWeb.Endpoint.config_change(changed, removed)
     :ok
+  end
+
+  defp cluster_topologies do
+    disabled = Application.get_env(:app_template, :cluster_disabled)
+    topologies = Application.get_env(:app_template, :cluster_topologies)
+
+    if disabled, do: [], else: topologies
   end
 
   defp setup do


### PR DESCRIPTION
This makes it so that we can use the same `release` binary but optionally disable the cluster typologies so that it doesn't try to have the node look for something that doesn't exist. This is especially the case when you deploy a single pod instance into a Kubernetes cluster without a service name defined for the nodes.

I think we should be fine leaving this enabled by default and disabling on an as-needed basis. This would typically be when we only need to run a single instance (e.g. review application).