### PR TITLE
Clustering gotchas

### DIFF
--- a/config/releases.exs
+++ b/config/releases.exs
@@ -2,10 +2,10 @@ import Config
 # NOTE: Runtime production configuration goes here
 
 config :app_template, AppTemplate.Repo,
-  database: "postgres",
+  database: System.get_env("POSTGRES_DATABASE") || "postgres",
   username: System.get_env("POSTGRES_USER"),
   password: System.get_env("POSTGRES_PASSWORD"),
-  hostname: "app-template-database",
+  hostname: System.get_env("POSTGRES_HOSTNAME") || "app-template-database",
   pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10")
 
 config :app_template, AppTemplateWeb.Endpoint,

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -30,7 +30,7 @@ config :app_template,
 # Configure Cluster Nodes
 app_name = System.get_env("APP_NAME") || "app-template"
 
-config :app_template, cluster_disabled: System.get_env("CLUSTER_DISABLED") == "1"
+config :app_template, cluster_enabled: System.get_env("CLUSTER_ENABLED") == "1"
 
 config :app_template,
   cluster_topologies: [

--- a/lib/app_template/application.ex
+++ b/lib/app_template/application.ex
@@ -33,10 +33,10 @@ defmodule AppTemplate.Application do
   end
 
   defp cluster_topologies do
-    disabled = Application.get_env(:app_template, :cluster_disabled)
+    enabled = Application.get_env(:app_template, :cluster_enabled)
     topologies = Application.get_env(:app_template, :cluster_topologies)
 
-    if disabled, do: [], else: topologies
+    if enabled, do: topologies, else: []
   end
 
   defp setup do

--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -16,5 +16,5 @@
 #   this app's k8s resources, which is probably `app-template` in prod but would be
 #   different in staging or review apps
 export RELEASE_DISTRIBUTION=name
-export RELEASE_NODE=${APP_NAME:-app-template}@$NODE_IP
+export RELEASE_NODE=${APP_NAME:-app-template}@${NODE_IP:-$(hostname)}
 export RELEASE_COOKIE=$COOKIE


### PR DESCRIPTION
#### Description:
- Make the default deployment easier w/o special knowledge of elixir clustering
  - Disable clustering by default
  - Use a fallback in case `NODE_IP` isn't specified
- Allow database hostname and database to be configured through env

#### TODO:
- [ ] Upon merging this, watch logs to ensure that libcluster isn't started and everything works fine
- [ ] Then make a change to the deployment to enable clustering
- [ ] Watch that deployment to make sure clustering _is_ enabled and everything works fine

#### Reviewer don't-forgets:

- [ ] Test coverage feels appropriate, given potential risk
- [ ] We're not doubling down on already-bad code
- [ ] If there are web UI changes, they don't add anything that could be considered client-side page navigation (unless pre-approved as being necessary by another engineer)
- [ ] If there are web UI changes, they don't add any AJAX form submits (unless pre-approved as being necessary by another engineer)
- [ ] If there are any lint rules disabled, they are disabled per-line, and were (in the reviewer's judgment) appropriate to disable
- [ ] Any new environment variables used in the app are both documented and have been added to both staging and production environments already
- [ ] Potential race conditions are either inconsequential, or the code prevents them from occurring.
- [ ] If this is a UI change that called for screenshots/GIFs, in the reviewer's judgement, they were included
