### PR TITLE
fix: Do not delete flashes when invalidating user

### DIFF
--- a/lib/app_template_web/plugs/browser_authentication.ex
+++ b/lib/app_template_web/plugs/browser_authentication.ex
@@ -26,8 +26,13 @@ defmodule AppTemplateWeb.BrowserAuthentication do
   end
 
   @impl true
-  def delete(conn, _config) do
-    configure_session(conn, drop: true)
+  def delete(conn, config) do
+    # Don't destroy the whole session, which includes flash. Just remove the
+    # current user.
+    conn
+    |> Pow.Plug.assign_current_user(nil, config)
+    |> assign(:user_id, nil)
+    |> put_session(:user_id, nil)
   end
 
   defp browser_auth(conn) do


### PR DESCRIPTION
Same as https://github.com/revelrylabs/saas-product-template/pull/101 on the saas-product-template.

All flashes which occur during a failed login were getting deleted because we were destroying the session, which includes the flash hash. I propose we switch to more narrowly removing the current user and user_id.