### PR TITLE
#738 update scrubber to keep maps as maps

### DIFF
--- a/lib/app_template/scrubber.ex
+++ b/lib/app_template/scrubber.ex
@@ -25,14 +25,17 @@ defmodule AppTemplate.Scrubber do
     iex> scrub(password: "password")
     [password: "[FILTERED]"]
 
-    iex> scrub(%{thing: %{in: %{thing: %{password: "asdf"}}}})
-    [thing: [in: [thing: [password: "[FILTERED]"]]]]
+    iex> scrub(%{"thing" => %{"with" => "strings", "creds" => %{"password" =>  "filterme"}}})
+    %{"thing" => %{"with" => "strings", "creds" => %{"password" => "[FILTERED]"}}}
 
-    iex> scrub(keyword_list: [%{inside_a_list_of_maps: [password: "bad"]}])
-    [keyword_list: [[inside_a_list_of_maps: [password: "[FILTERED]"]]]]
+    iex> scrub(%{thing: %{in: %{thing: %{password: "asdf"}}}})
+    %{thing: %{in: %{thing: %{password: "[FILTERED]"}}}}
+
+    iex> scrub(keyword_list: [%{inside_a_list_of_maps: %{password: "bad"}}])
+    [keyword_list: [%{inside_a_list_of_maps: %{password: "[FILTERED]"}}]]
 
     iex> scrub({[%{password: "test"}]})
-    {[[password: "[FILTERED]"]]}
+    {[%{password: "[FILTERED]"}]}
   """
   def scrub(data) when is_tuple(data) do
     case data do
@@ -49,6 +52,6 @@ defmodule AppTemplate.Scrubber do
 
   def scrub(%{__struct__: _} = data), do: data |> Map.from_struct() |> scrub()
   def scrub(data) when is_list(data), do: Enum.map(data, &scrub/1)
-  def scrub(data) when is_map(data), do: Enum.map(data, &scrub/1)
+  def scrub(data) when is_map(data), do: Enum.into(data, %{}, &scrub/1)
   def scrub(other), do: other
 end


### PR DESCRIPTION
connects to #738 

#### Description:
Update the scrubber to preserve maps as maps, to avoid issues when trying to JSON-encode tuples.


#### Reviewer don't-forgets:

- [ ] Test coverage feels appropriate, given potential risk
- [ ] We're not doubling down on already-bad code
- [ ] If there are web UI changes, they don't add anything that could be considered client-side page navigation (unless pre-approved as being necessary by another engineer)
- [ ] If there are web UI changes, they don't add any AJAX form submits (unless pre-approved as being necessary by another engineer)
- [ ] If there are any lint rules disabled, they are disabled per-line, and were (in the reviewer's judgment) appropriate to disable
- [ ] Any new environment variables used in the app are both documented and have been added to both staging and production environments already
- [ ] Potential race conditions are either inconsequential, or the code prevents them from occurring.
- [ ] If this is a UI change that called for screenshots/GIFs, in the reviewer's judgement, they were included
