### PR TITLE
Bump elixir in .tool-version, .travis.yml, and Dockerfile to Elixir 1.11.3

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 nodejs 14.0.0
 erlang 22.3
-elixir 1.10.4-otp-22
+elixir  1.11.3-otp-22
 kubectl 1.16.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: elixir
 
 elixir:
-  - 1.10.4
+  -  1.11.3
 
 otp_release:
   - 22.1.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Set the Docker image you want to base your image off.
-FROM elixir:1.10.4 as builder
+FROM elixir: 1.11.3 as builder
 
 ENV MIX_ENV="prod" \
   PORT="5000"


### PR DESCRIPTION
connects to #897 

#### Description: updated .tool-version, .travis.yml, and Dockerfile to Elixir 1.11.3.

#### Reviewer don't-forgets:

- [ ] Test coverage feels appropriate, given potential risk
- [ ] We're not doubling down on already-bad code
- [ ] If there are web UI changes, they don't add anything that could be considered client-side page navigation (unless pre-approved as being necessary by another engineer)
- [ ] If there are web UI changes, they don't add any AJAX form submits (unless pre-approved as being necessary by another engineer)
- [ ] If there are any lint rules disabled, they are disabled per-line, and were (in the reviewer's judgment) appropriate to disable
- [ ] Any new environment variables used in the app are both documented and have been added to both staging and production environments already
- [ ] Potential race conditions are either inconsequential, or the code prevents them from occurring.
- [ ] If this is a UI change that called for screenshots/GIFs, in the reviewer's judgement, they were included
