### PR TITLE
Deploy fix //  fix SSL deploy error before-script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ install:
   - nvm install 12.4.0 && nvm use 12.4.0
 
 before_script:
+  - sudo rm /etc/ssl/certs/DST_Root_CA_X3.pem || echo "expired LetsEncrypt root not found at /etc/ssl/certs/DST_Root_CA_X3.pem"
   - mix local.hex --force
   - mix local.rebar --force
   - mix deps.get


### PR DESCRIPTION
#### Description: <!-- What changed? Why? -->

I tried to merge #986 and this blocked me. Luckily, I know how to fix this.

This should fix the issue with deploys failing due to the SSL issue:

```
/home/travis/.rvm/rubies/ruby-2.5.3/lib/ruby/2.5.0/net/protocol.rb:44:in `connect_nonblock': SSL_connect returned=1 errno=0 state=error: certificate verify failed (certificate has expired) (OpenSSL::SSL::SSLError)
```



#### Reviewer don't-forgets:

- [ ] Test coverage feels appropriate, given potential risk
- [ ] We're not doubling down on already-bad code
- [ ] If there are web UI changes, they don't add anything that could be considered client-side page navigation (unless pre-approved as being necessary by another engineer)
- [ ] If there are web UI changes, they don't add any AJAX form submits (unless pre-approved as being necessary by another engineer)
- [ ] If there are any lint rules disabled, they are disabled per-line, and were (in the reviewer's judgment) appropriate to disable
- [ ] Any new environment variables used in the app are both documented and have been added to both staging and production environments already
- [ ] Potential race conditions are either inconsequential, or the code prevents them from occurring.
- [ ] If this is a UI change that called for screenshots/GIFs, in the reviewer's judgement, they were included
